### PR TITLE
Add Message-Authenticator

### DIFF
--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -2,6 +2,9 @@ package collector
 
 import (
 	"context"
+	"crypto/hmac"
+	"crypto/md5"
+	"errors"
 	"fmt"
 	"net"
 	"sync"
@@ -12,16 +15,21 @@ import (
 
 	"layeh.com/radius"
 	"layeh.com/radius/rfc2865"
+	"layeh.com/radius/rfc2869"
 )
 
+const secret = "5ecr3t"
+
 type TestServer struct {
-	Address     string
-	AcceptCount int
-	RejectCount int
-	mtx         sync.Mutex
-	started     bool
-	pc          net.PacketConn
-	ps          *radius.PacketServer
+	Address             string
+	AcceptCount         int
+	RejectCount         int
+	ValidMsgAuthCount   int
+	InvalidMsgAuthCount int
+	mtx                 sync.Mutex
+	started             bool
+	pc                  net.PacketConn
+	ps                  *radius.PacketServer
 }
 
 func NewTestServer(username string, password string, secret string) *TestServer {
@@ -53,6 +61,14 @@ func NewTestServer(username string, password string, secret string) *TestServer 
 			code = radius.CodeAccessReject
 		}
 
+		ts.mtx.Lock()
+		if err = ts.ValidateMessageAuthenticator(r.Packet, secret); err != nil {
+			ts.InvalidMsgAuthCount++
+		} else {
+			ts.ValidMsgAuthCount++
+		}
+		ts.mtx.Unlock()
+
 		w.Write(r.Response(code))
 	}
 
@@ -62,6 +78,45 @@ func NewTestServer(username string, password string, secret string) *TestServer 
 	}
 
 	return ts
+}
+
+// ValidateMessageAuthenticator validates the Message-Authenticator attribute in a RADIUS packet
+// as per RFC 3579. It returns nil if valid, or an error if invalid.
+func (ts *TestServer) ValidateMessageAuthenticator(packet *radius.Packet, sharedSecret string) error {
+	// Check if Message-Authenticator attribute exists
+	messageAuth := rfc2869.MessageAuthenticator_Get(packet)
+
+	// Store original Message-Authenticator and zero it out for HMAC calculation
+	originalMessageAuth := make([]byte, len(messageAuth))
+	copy(originalMessageAuth, messageAuth)
+	err := rfc2869.MessageAuthenticator_Set(packet, make([]byte, 16)) // Set to 16 zero bytes
+	if err != nil {
+		return errors.New("failed to set zero MessageAuthenticator: " + err.Error())
+	}
+
+	// Get the raw packet bytes for HMAC calculation
+	rawPacket, err := packet.Encode()
+	if err != nil {
+		return errors.New("failed to encode packet: " + err.Error())
+	}
+
+	// Calculate HMAC-MD5 of the entire packet using the shared secret
+	h := hmac.New(md5.New, []byte(sharedSecret))
+	h.Write(rawPacket)
+	computedMessageAuth := h.Sum(nil)
+
+	// Restore original Message-Authenticator
+	err = rfc2869.MessageAuthenticator_Set(packet, originalMessageAuth)
+	if err != nil {
+		return errors.New("failed to set MessageAuthenticator: " + err.Error())
+	}
+
+	// Compare computed HMAC with received Message-Authenticator
+	if !hmac.Equal(computedMessageAuth, originalMessageAuth) {
+		return errors.New("Message-Authenticator validation failed")
+	}
+
+	return nil
 }
 
 func (ts *TestServer) Start() {
@@ -82,7 +137,6 @@ func (ts *TestServer) Close() {
 func TestProbeAccessAccept(t *testing.T) {
 	user := "testUser"
 	password := "testPassowrd"
-	secret := "5ecr3t"
 
 	ts := NewTestServer(user, password, secret)
 	ts.Start()
@@ -111,5 +165,13 @@ func TestProbeAccessAccept(t *testing.T) {
 	}
 	if ts.RejectCount != 0 {
 		t.Errorf("expected 0 Access-Reject got %d", ts.RejectCount)
+	}
+
+	if ts.InvalidMsgAuthCount != 0 {
+		t.Errorf("expected 0 Invalid MessageAuthenticators got %d", ts.InvalidMsgAuthCount)
+	}
+
+	if ts.ValidMsgAuthCount != 1 {
+		t.Errorf("expected 1 Valid MessageAuthenticators got %d", ts.InvalidMsgAuthCount)
 	}
 }


### PR DESCRIPTION
FreeRADIUS3 complains if the Message-Authenticator is not set. This change adds the computed Message-Authenticator.